### PR TITLE
Fixed back_url redirection using Saml plugin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -223,10 +223,12 @@ class ApplicationController < ActionController::Base
           if request.xhr?
             head :unauthorized
           else
+            cookies[:back_url] = url
             redirect_to signin_path(:back_url => url)
           end
         }
         format.any(:atom, :pdf, :csv) {
+          cookies[:back_url] = url
           redirect_to signin_path(:back_url => url)
         }
         format.xml  { head :unauthorized, 'WWW-Authenticate' => 'Basic realm="Redmine API"' }
@@ -394,7 +396,7 @@ class ApplicationController < ActionController::Base
   end
 
   def back_url
-    url = params[:back_url]
+    url = cookies[:back_url]
     if url.nil? && referer = request.env['HTTP_REFERER']
       url = CGI.unescape(referer.to_s)
       # URLs that contains the utf8=[checkmark] parameter added by Rails are
@@ -408,8 +410,9 @@ class ApplicationController < ActionController::Base
   helper_method :back_url
 
   def redirect_back_or_default(default, options={})
-    if back_url = validate_back_url(params[:back_url].to_s)
+    if back_url = validate_back_url(cookies[:back_url].to_s)
       redirect_to(back_url)
+      cookies.delete :back_url
       return
     elsif options[:referer]
       redirect_to_referer_or default

--- a/app/views/account/login.html.erb
+++ b/app/views/account/login.html.erb
@@ -4,8 +4,8 @@
   <%= form_tag(signin_path, onsubmit: 'return keepAnchorOnSignIn(this);') do %>
   <%= back_url_hidden_field_tag %>
 
-  <a href="/auth/saml">
-    <img class="mslogin" src="../themes/zenmine/customize/ms-symbollockup_signin_dark.svg" alt="ms_logo">
+  <a class="mslogin" href="/auth/saml">
+    <img src="../themes/zenmine/customize/ms-symbollockup_signin_dark.svg" alt="ms_logo">
   </a>
 
   <label for="username"><%=l(:field_login)%></label>


### PR DESCRIPTION
- Changed "back_url" from being a url param to being a cookie. 

The url param gets lost when the user gets redirected to Microsoft for the login, using cookies Redmine is able to retrieve this value after login and redirect the user to the desired url.

- Fixed the html of the Microsoft login button to work with the CSS

____________________________________________________________________

Your contributions to Redmine are welcome!

Please **open an issue on the [official website]** instead of sending pull requests.

Since the development of Redmine is not conducted on GitHub but on the [official website] and core developers are not monitoring the GitHub repo, pull requests might not get reviewed.

For more detail about how to contribute, please see the wiki page [Contribute] on the [official website].

[official website]: https://www.redmine.org/
[Contribute]: https://www.redmine.org/projects/redmine/wiki/Contribute
